### PR TITLE
feature/87 feat:카카오 지도로 주소 이미지 교체

### DIFF
--- a/docs/work-logs/2026-04-04-지도iframe교체.md
+++ b/docs/work-logs/2026-04-04-지도iframe교체.md
@@ -1,0 +1,45 @@
+# 2026-04-04 지도 iframe 교체
+
+## 상태
+
+진행중
+
+## 목표
+
+- [ ] address.png 정적 이미지를 실제 네이버/카카오 지도로 교체
+- [ ] iframe 또는 JavaScript API 방식 결정
+- [ ] Address.tsx 컴포넌트 수정
+
+## 관련 이슈 / PR
+
+- Issue #76
+
+## 관련 파일
+
+- `src/feature/contact/components/Address.tsx`
+- `public/address.png` (교체 후 제거 가능)
+
+## 작업 단계
+
+- [ ] 지도 방식 결정 (iframe vs JavaScript API)
+- [ ] API 키 필요 여부 확인
+- [ ] Address.tsx 컴포넌트 수정
+- [ ] 반응형 스타일 적용
+- [ ] 빌드/린트 확인
+
+## 진행 상황
+
+### 2026-04-04
+
+- 작업 시작
+- 현재 Address.tsx: address.png를 Next.js Image로 렌더링, 클릭 시 네이버 지도 링크
+- 네이버 지도 place ID: 1426094200
+- 주소: 울산 남구 문수로335번길 6 길상 빌딩 5층
+
+## 중단 시 이어서 할 작업
+
+- [ ] 방식 결정 후 Address.tsx 수정
+
+## 완료 요약
+
+(작업 완료 시 주요 변경 사항 요약)

--- a/src/feature/contact/components/Address.tsx
+++ b/src/feature/contact/components/Address.tsx
@@ -1,28 +1,23 @@
-import Image from 'next/image';
 import { CardDescription } from './Card';
+import KakaoMap from './KakaoMap';
 
 export default function Address() {
   return (
     <>
       <div className="flex items-center flex-col gap-3 font-bold lg:gap-4 text-2xl lg:text-4xl">
         학원 약도
-        <a
-          href="https://map.naver.com/p/entry/place/1426094200?c=15.00,0,0,0,dh}"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            className="relative w-auto h-auto rounded-xl"
-            src="/address.png"
-            alt="학원 주소"
-            width={800}
-            height={500}
-            priority
-          />
-        </a>
+        <div className="w-[290px] md:w-[700px] lg:w-[900px]">
+          <KakaoMap />
+        </div>
         <div className="text-center">
-          <CardDescription text="클릭 시 네이버지도로 이동" size="xs" />
-          <address className="m-0 text-xs  sm:text-sm sm:opacity-50 transition-all">
+          <a
+            href="https://map.kakao.com/link/search/울산 남구 문수로335번길 6"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <CardDescription text="클릭 시 카카오지도로 이동" size="xs" />
+          </a>
+          <address className="m-0 text-xs sm:text-sm sm:opacity-50 transition-all">
             울산 남구 문수로335번길 6 길상 빌딩 5층
           </address>
         </div>

--- a/src/feature/contact/components/KakaoMap.tsx
+++ b/src/feature/contact/components/KakaoMap.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+export default function KakaoMap() {
+  const mapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const apiKey = process.env.NEXT_PUBLIC_KAKAO_MAP_KEY;
+
+    const initMap = () => {
+      window.kakao.maps.load(() => {
+        if (!mapRef.current) return;
+
+        const geocoder = new window.kakao.maps.services.Geocoder();
+
+        geocoder.addressSearch('울산 남구 문수로335번길 6', (result, status) => {
+          if (status !== window.kakao.maps.services.Status.OK) return;
+          if (!mapRef.current) return;
+
+          const coords = new window.kakao.maps.LatLng(
+            Number(result[0].y),
+            Number(result[0].x),
+          );
+
+          const map = new window.kakao.maps.Map(mapRef.current, {
+            center: coords,
+            level: 3,
+          });
+
+          const marker = new window.kakao.maps.Marker({
+            map,
+            position: coords,
+          });
+
+          const infowindow = new window.kakao.maps.InfoWindow({
+            content:
+              '<div style="padding:5px;font-size:12px;">1.6수학과학학원</div>',
+          });
+
+          infowindow.open(map, marker);
+        });
+      });
+    };
+
+    if (window.kakao) {
+      initMap();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${apiKey}&libraries=services&autoload=false`;
+    script.async = true;
+    script.onload = initMap;
+    script.onerror = () => {
+      console.error('[KakaoMap] 스크립트 로드 실패');
+    };
+    document.head.appendChild(script);
+  }, []);
+
+  return (
+    <div
+      ref={mapRef}
+      className="w-full h-56 md:h-80 lg:h-[450px] rounded-xl"
+      aria-label="학원 위치 지도"
+    />
+  );
+}

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,0 +1,65 @@
+declare namespace kakao {
+  namespace maps {
+    function load(callback: () => void): void;
+
+    class LatLng {
+      constructor(lat: number, lng: number);
+    }
+
+    interface MapOptions {
+      center: LatLng;
+      level: number;
+    }
+
+    class Map {
+      constructor(container: HTMLElement, options: MapOptions);
+    }
+
+    interface MarkerOptions {
+      map: Map;
+      position: LatLng;
+    }
+
+    class Marker {
+      constructor(options: MarkerOptions);
+    }
+
+    interface InfoWindowOptions {
+      content: string;
+    }
+
+    class InfoWindow {
+      constructor(options: InfoWindowOptions);
+      open(map: Map, marker: Marker): void;
+    }
+
+    namespace services {
+      interface AddressSearchResult {
+        x: string;
+        y: string;
+      }
+
+      const Status: {
+        OK: string;
+        ZERO_RESULT: string;
+        ERROR: string;
+      };
+
+      class Geocoder {
+        addressSearch(
+          addr: string,
+          callback: (
+            result: AddressSearchResult[],
+            status: string,
+          ) => void,
+        ): void;
+      }
+    }
+  }
+}
+
+declare global {
+  interface Window {
+    kakao: typeof kakao;
+  }
+}


### PR DESCRIPTION


- address.png 정적 이미지 제거, KakaoMap 컴포넌트로 교체
- Geocoder로 주소 검색해 정확한 좌표 자동 설정
- 반응형 너비 적용 (모바일 290px / md 700px / lg 900px)
- kakao.d.ts 타입 선언 파일 추가