### PR TITLE
학원명 수학과학전문학원으로 변경 및 네이버 지도 연동

### DIFF
--- a/docs/work-logs/2026-04-11-학원명변경및네이버지도연동.md
+++ b/docs/work-logs/2026-04-11-학원명변경및네이버지도연동.md
@@ -1,0 +1,45 @@
+# 학원명 변경 및 네이버 지도 연동
+
+## 상태
+
+완료
+
+## 목표
+
+- [ ] 전체 학원명 "수학 전문학원" → "수학과학학원" 변경
+- [ ] 시멘틱 태그 개선 (ContentWrapper h1→h2, JsonLd section→fragment 등)
+- [ ] /contact 지도 클릭 시 네이버 지도 연동
+
+## 관련 이슈 / PR
+
+- 브랜치: feature/80
+
+## 관련 파일
+
+- `src/shared/components/Header.tsx`
+- `src/app/layout.tsx`
+- `src/feature/introduce/components/ContentWrapper.tsx`
+- `src/shared/components/JsonLd.tsx`
+- `src/feature/contact/components/Address.tsx`
+- `src/feature/contact/components/KakaoMap.tsx`
+
+## 작업 단계
+
+- [ ] 학원명 변경 (Header, layout metadata)
+- [ ] 시멘틱 태그 개선
+- [ ] 네이버 지도 클릭 연동
+
+## 진행 상황
+
+### 2026-04-11
+
+- 작업 시작
+- 파일 구조 파악: KakaoMap 지도 표시 + Address에서 카카오지도 링크
+
+## 중단 시 이어서 할 작업
+
+- 없음
+
+## 완료 요약
+
+(작업 완료 시 주요 변경 사항 요약)

--- a/src/app/(users)/contact/page.tsx
+++ b/src/app/(users)/contact/page.tsx
@@ -4,10 +4,12 @@ import Address from '@/feature/contact/components/Address';
 export default function Contact() {
   return (
     <main className="flex min-h-screen flex-col items-center lg:p-14">
-      <div className="relative flex place-items-center before:absolute before:h-[300px] before:w-full before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 sm:before:w-[480px] sm:after:w-[240px] before:lg:h-[360px] m-10">
+      <section className="m-10" aria-label="학원 위치">
         <Address />
-      </div>
-      <CardList />
+      </section>
+      <section aria-label="연락처 정보">
+        <CardList />
+      </section>
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,18 +7,18 @@ import GoogleAnalytics from '@/shared/components/GoogleAnalytics';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: '1.6 수학전문학원',
+  title: '1.6 수학과학전문학원',
   description:
-    '울산 남구 옥동 1.6 수학학원입니다. \n 네이버 지도 이용시에는 일점육수학과학전문학원으로 검색 부탁드립니다.',
+    '울산 남구 옥동 1.6 수학과학전문학원입니다. 일점육수학과학전문학원으로도 검색하실 수 있습니다.',
   openGraph: {
-    title: '1.6 수학전문학원',
-    description: '울산 남구 옥동 1.6수학전문학원(일점육수학전문학원)입니다.',
+    title: '1.6 수학과학전문학원',
+    description: '울산 남구 옥동 1.6수학과학전문학원(일점육수학과학전문학원)입니다.',
     images:
       'https://github.com/suhong99/1.6math/assets/120103909/205269b2-3969-4afd-8477-686a46aa76c8',
     locale: 'ko_KR',
     url: 'https://1-6math.vercel.app/',
     type: 'website',
-    siteName: '1.6 수학전문학원',
+    siteName: '1.6 수학과학전문학원',
   },
 };
 export default function RootLayout({

--- a/src/feature/admin/AdminHeader.tsx
+++ b/src/feature/admin/AdminHeader.tsx
@@ -7,7 +7,7 @@ export default async function AdminHeader() {
   const session = await auth();
   return (
     <header className="w-full  sticky top-0 flex  p-2.5 px-6 lg:px-10 bg-white z-[800] border-b border-gray-500 lg:gap-8 items-end justify-between">
-      <h1 className="font-extrabold text-xl lg:text-3xl">1.6 수학 전문학원</h1>
+      <h1 className="font-extrabold text-xl lg:text-3xl">1.6 수학과학전문학원</h1>
       <div className="min-h-[50px] flex justify-center items-center">
         {!session?.user ? <SignIn /> : <SignOut />}
       </div>{' '}

--- a/src/feature/contact/components/Address.tsx
+++ b/src/feature/contact/components/Address.tsx
@@ -1,21 +1,33 @@
 import { CardDescription } from './Card';
 import KakaoMap from './KakaoMap';
+import { NAVER_MAP_URL } from '@/shared/const';
 
 export default function Address() {
   return (
     <>
       <div className="flex items-center flex-col gap-3 font-bold lg:gap-4 text-2xl lg:text-4xl">
-        학원 약도
-        <div className="w-[290px] md:w-[700px] lg:w-[900px]">
+        <h2 className="text-2xl lg:text-4xl font-bold">학원 약도</h2>
+        <a
+          href={NAVER_MAP_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="relative block w-[290px] md:w-[700px] lg:w-[900px] group"
+          aria-label="네이버 지도에서 학원 위치 보기"
+        >
           <KakaoMap />
-        </div>
+          <span className="absolute inset-0 flex items-end justify-center pb-3 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+            <span className="bg-black/60 text-white text-sm px-3 py-1 rounded-full">
+              클릭 시 네이버지도로 이동
+            </span>
+          </span>
+        </a>
         <div className="text-center">
           <a
-            href="https://map.kakao.com/link/search/울산 남구 문수로335번길 6"
+            href={NAVER_MAP_URL}
             target="_blank"
             rel="noopener noreferrer"
           >
-            <CardDescription text="클릭 시 카카오지도로 이동" size="xs" />
+            <CardDescription text="클릭 시 네이버지도로 이동" size="xs" />
           </a>
           <address className="m-0 text-xs sm:text-sm sm:opacity-50 transition-all">
             울산 남구 문수로335번길 6 길상 빌딩 5층

--- a/src/feature/contact/components/KakaoMap.tsx
+++ b/src/feature/contact/components/KakaoMap.tsx
@@ -35,7 +35,7 @@ export default function KakaoMap() {
 
           const infowindow = new window.kakao.maps.InfoWindow({
             content:
-              '<div style="padding:5px;font-size:12px;">1.6수학과학학원</div>',
+              '<div style="padding:5px;font-size:12px;">1.6수학과학전문학원</div>',
           });
 
           infowindow.open(map, marker);

--- a/src/feature/introduce/components/ContentWrapper.tsx
+++ b/src/feature/introduce/components/ContentWrapper.tsx
@@ -8,7 +8,7 @@ interface Props {
 const ContentWrapper: React.FC<Props> = ({ title, children }) => {
   return (
     <div className="bg-gray-100 p-6 rounded-lg shadow-lg max-w-4xl text-gray-800 leading-relaxed lg:px-12 mt-7 sm:mx-6 mx-4 mb-3">
-      <h1 className="text-3xl font-extrabold mb-6">{title}</h1>
+      <h2 className="text-3xl font-extrabold mb-6">{title}</h2>
       {children}
     </div>
   );

--- a/src/feature/introduce/components/System.tsx
+++ b/src/feature/introduce/components/System.tsx
@@ -11,7 +11,7 @@ export default function System() {
       <div className="lg:flex-[3] lg:pr-8 flex items-center">
         <p className="text-xl leading-relaxed mb-6">
           수험생에게는 확실한 개념 이해와 꾸준한 복습이 중요합니다.
-          1.6수학전문학원은 단순한 수업에 그치지 않고, 주말 테스트를 통해 학습한
+          1.6수학과학전문학원은 단순한 수업에 그치지 않고, 주말 테스트를 통해 학습한
           내용을 철저히 점검하며, 오답노트를 활용해 놓친 부분을 반복 복습하도록
           합니다. 이를 통해 개념을 확실히 다지고 꾸준한 성장을 이끌어내어,
           학생들의 실력 향상을 책임집니다.

--- a/src/shared/components/FloatingBtn.tsx
+++ b/src/shared/components/FloatingBtn.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import React from 'react';
 import { useRouter } from 'next/navigation'; // useRouter import
-import { PHONE_DATA } from '../const';
+import { PHONE_DATA, NAVER_MAP_URL } from '../const';
 
 const FloatingBtn = () => {
   const router = useRouter(); // useRouter 호출
@@ -24,11 +24,7 @@ const FloatingBtn = () => {
       alt: '길찾기',
       text: '길 찾기',
       func: () => {
-        window.open(
-          'https://map.naver.com/p/entry/place/1426094200?c=15.00,0,0,0,dh',
-          '_blank',
-          'noopener,noreferrer'
-        );
+        window.open(NAVER_MAP_URL, '_blank', 'noopener,noreferrer');
       },
     },
     {

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -5,7 +5,7 @@ import MobileSidebar from './MobileSidebar';
 export default function Header() {
   return (
     <header className="w-full  sticky top-0 flex  p-2.5 px-6 lg:px-10 bg-white z-[800] border-b border-gray-500 lg:gap-8 items-end justify-between lg:justify-normal">
-      <h1 className="font-extrabold text-3xl">1.6 수학 전문학원</h1>
+      <h1 className="font-extrabold text-3xl">1.6 수학과학전문학원</h1>
       {/* 600px 이상: NavLinks 표시 */}
       <div className="hidden lg:block">
         <NavLinks />

--- a/src/shared/components/JsonLd.tsx
+++ b/src/shared/components/JsonLd.tsx
@@ -33,7 +33,7 @@ export default function JsonLd() {
   const OrgJson = {
     '@context': 'https://schema.org',
     '@type': 'Organization',
-    name: '1.6수학과학학원',
+    name: '1.6수학과학전문학원',
     description: '옥동에서 수학을 전문적으로 가르치고 있습니다.',
     address: {
       '@type': 'PostalAddress',
@@ -52,7 +52,7 @@ export default function JsonLd() {
   };
 
   return (
-    <section>
+    <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(OrgJson) }}
@@ -61,6 +61,6 @@ export default function JsonLd() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(JsonLd) }}
       />
-    </section>
+    </>
   );
 }

--- a/src/shared/components/MobileSidebar.tsx
+++ b/src/shared/components/MobileSidebar.tsx
@@ -63,7 +63,7 @@ const MobileSidebar = () => {
             </div>
 
             {/* 하단 여백 */}
-            <div className="p-6 text-gray-500 text-sm">© 1.6 수학 전문학원</div>
+            <div className="p-6 text-gray-500 text-sm">© 1.6 수학과학전문학원</div>
           </div>
         </>
       )}

--- a/src/shared/const/index.ts
+++ b/src/shared/const/index.ts
@@ -1,3 +1,6 @@
+export const NAVER_MAP_URL =
+  'https://map.naver.com/p/entry/place/2026739720?c=17.25,0,0,0,dh&placePath=/home?from=map&fromPanelNum=1&additionalHeight=76&timestamp=202604111922&locale=ko&svcName=map_pcv5';
+
 export const NAVIGATION_LIST = [
   { label: '학원 소개', url: '/' },
   { label: '오시는 길', url: '/contact' },


### PR DESCRIPTION
- 전체 학원명 '수학전문학원' → '1.6수학과학전문학원'으로 변경
- /contact 지도 클릭 시 네이버 지도로 이동하도록 연동
- NAVER_MAP_URL 상수화하여 FloatingBtn, Address에서 공유
- 시멘틱 태그 개선: ContentWrapper h1→h2, JsonLd section→fragment, contact page section 구조화