### PR TITLE
fix: 오시는길/문의함 색상 통일 및 FloatingBtn 스피드 다이얼 리팩토링

### DIFF
--- a/docs/work-logs/2026-04-13-UI색상통일및FloatingBtn리팩토링.md
+++ b/docs/work-logs/2026-04-13-UI색상통일및FloatingBtn리팩토링.md
@@ -1,0 +1,51 @@
+# UI 색상 통일 및 FloatingBtn 리팩토링
+
+## 개요
+
+- **시작일**: 2026-04-13
+- **상태**: 완료
+- **관련 브랜치**: feature/86
+
+## 목표
+
+### 오시는길 / 문의함 색상 통일
+
+- [x] Contact 페이지 → ContentWrapper + slate/amber 색상 시스템 적용
+- [x] Card 컴포넌트 → gray 계열 제거, slate/amber 통일
+- [x] Address 컴포넌트 → 색상 결 통일
+- [x] Suggest 페이지 → ContentWrapper 구조 + slate/amber 색상
+- [x] SuggestForm → gray/blue → slate/amber 색상 교체
+
+### FloatingBtn 스피드 다이얼
+
+- [x] amber FAB 하나로 축소 (평상시 공간 최소화)
+- [x] 클릭 시 3개 옵션 위로 펼침 (스피드 다이얼)
+- [x] slate-900 + amber-500 색상 시스템 통일
+- [x] SVG 이미지 → 인라인 SVG로 교체 (색상 제어)
+- [x] 임의값 제거, 반응형 정비
+
+## 진행 상황
+
+### 2026-04-13
+
+- 어제 리디자인 색상 시스템 확인: slate-900/800 다크 + amber-500/400 강조 + bg-white 라이트
+- Contact/Suggest 페이지에 ContentWrapper 구조 적용, gray 계열 전부 slate/amber로 교체
+- FloatingBtn을 스피드 다이얼 방식으로 전면 교체 (기존 흰 원형 3개 → amber FAB + 펼침 옵션)
+
+## 실행 스크립트
+
+```bash
+npm run dev
+npm run build
+```
+
+## 관련 파일
+
+- `src/app/(users)/contact/page.tsx`
+- `src/app/(users)/suggest/page.tsx`
+- `src/feature/contact/components/Card.tsx`
+- `src/feature/contact/components/CardList.tsx`
+- `src/feature/contact/components/Address.tsx`
+- `src/feature/suggest/component/SuggestForm.tsx`
+- `src/shared/components/FloatingBtn.tsx`
+- `src/app/(users)/layout.tsx`

--- a/src/app/(users)/contact/page.tsx
+++ b/src/app/(users)/contact/page.tsx
@@ -1,15 +1,17 @@
 import CardList from '@/feature/contact/components/CardList';
 import Address from '@/feature/contact/components/Address';
+import ContentWrapper from '@/feature/introduce/components/ContentWrapper';
 
 export default function Contact() {
   return (
-    <main className="flex min-h-screen flex-col items-center lg:p-14">
-      <section className="m-10" aria-label="학원 위치">
+    <main className="flex flex-col">
+      <ContentWrapper title="오시는 길" subtitle="학원 위치 & 약도">
         <Address />
-      </section>
-      <section aria-label="연락처 정보">
+      </ContentWrapper>
+
+      <ContentWrapper title="연락처" subtitle="상담 & 문의" dark>
         <CardList />
-      </section>
+      </ContentWrapper>
     </main>
   );
 }

--- a/src/app/(users)/suggest/page.tsx
+++ b/src/app/(users)/suggest/page.tsx
@@ -1,13 +1,21 @@
 import SuggestForm from '@/feature/suggest/component/SuggestForm';
+import ContentWrapper from '@/feature/introduce/components/ContentWrapper';
 
 export default function Suggest() {
   return (
-    <main className="space-y-6 p-6 shadow-md rounded-lg mx-auto mt-4 lg:max-w-2xl w-full">
-      <h1 className="text-2xl font-bold text-center text-gray-800">제보하기</h1>
-      <SuggestForm />
-      <p className="text-gray-600 text-center text-sm">
-        학부모님의 소중한 목소리에 귀 기울이겠습니다.
-      </p>
+    <main className="flex flex-col">
+      <ContentWrapper
+        title="익명 건의함"
+        subtitle="소중한 의견을 남겨주세요"
+      >
+        <div className="max-w-2xl mx-auto w-full">
+          <p className="text-slate-500 text-sm lg:text-base mb-8 leading-relaxed">
+            학부모님과 학생의 소중한 목소리에 귀 기울이겠습니다.
+            익명으로 자유롭게 의견을 남겨주세요.
+          </p>
+          <SuggestForm />
+        </div>
+      </ContentWrapper>
     </main>
   );
 }

--- a/src/feature/contact/components/Address.tsx
+++ b/src/feature/contact/components/Address.tsx
@@ -1,39 +1,43 @@
-import { CardDescription } from './Card';
 import KakaoMap from './KakaoMap';
 import { NAVER_MAP_URL } from '@/shared/const';
 
 export default function Address() {
   return (
-    <>
-      <div className="flex items-center flex-col gap-3 font-bold lg:gap-4 text-2xl lg:text-4xl">
-        <h2 className="text-2xl lg:text-4xl font-bold">학원 약도</h2>
+    <div className="flex flex-col items-center gap-6">
+      {/* 지도 */}
+      <a
+        href={NAVER_MAP_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="relative block w-full max-w-3xl group rounded-2xl overflow-hidden shadow-lg"
+        aria-label="네이버 지도에서 학원 위치 보기"
+      >
+        <KakaoMap />
+        <span className="absolute inset-0 flex items-end justify-center pb-4 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+          <span className="bg-slate-900/80 text-amber-300 text-sm px-4 py-1.5 rounded-full font-medium border border-amber-500/40">
+            클릭 시 네이버지도로 이동
+          </span>
+        </span>
+      </a>
+
+      {/* 주소 정보 */}
+      <div className="text-center space-y-1">
+        <address className="not-italic text-slate-600 text-sm lg:text-base font-medium">
+          울산 남구 문수로335번길 6 길상 빌딩 5층
+        </address>
         <a
           href={NAVER_MAP_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="relative block w-[290px] md:w-[700px] lg:w-[900px] group"
-          aria-label="네이버 지도에서 학원 위치 보기"
+          className="inline-flex items-center gap-1.5 text-amber-600 hover:text-amber-500 text-sm font-medium transition-colors"
         >
-          <KakaoMap />
-          <span className="absolute inset-0 flex items-end justify-center pb-3 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
-            <span className="bg-black/60 text-white text-sm px-3 py-1 rounded-full">
-              클릭 시 네이버지도로 이동
-            </span>
-          </span>
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          네이버지도에서 보기
         </a>
-        <div className="text-center">
-          <a
-            href={NAVER_MAP_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <CardDescription text="클릭 시 네이버지도로 이동" size="xs" />
-          </a>
-          <address className="m-0 text-xs sm:text-sm sm:opacity-50 transition-all">
-            울산 남구 문수로335번길 6 길상 빌딩 5층
-          </address>
-        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/feature/contact/components/Card.tsx
+++ b/src/feature/contact/components/Card.tsx
@@ -1,24 +1,6 @@
 'use client';
 import React, { ReactNode } from 'react';
 
-type CardLink = {
-  link: string;
-  children: ReactNode;
-};
-
-function CardLinkWrapper({ link, children }: CardLink) {
-  return (
-    <a
-      href={link}
-      className="rounded-lg border h-full px-5 py-4 transition-color border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30 w-full max-w-96"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {children}
-    </a>
-  );
-}
-
 type CardClip = {
   text: string;
   children: ReactNode;
@@ -32,7 +14,7 @@ function CardClipWrapper({ text, children }: CardClip) {
   return (
     <button
       onClick={copylink}
-      className="flex flex-col items-start lg:text-left group rounded-lg border h-full px-5 py-4 transition-color border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30 w-full max-w-96"
+      className="flex flex-col items-start text-left group rounded-2xl border h-full px-5 py-5 transition-colors border-slate-700 bg-slate-800 hover:border-amber-500/50 hover:bg-slate-800/80 w-full max-w-96"
     >
       <span className="sr-only">클릭시 번호가 클립보드에 저장됩니다</span>
       {children}
@@ -42,13 +24,13 @@ function CardClipWrapper({ text, children }: CardClip) {
 
 function CardTitle({ title }: { title: string }) {
   return (
-    <div className="mb-3 text-2xl font-semibold w-full">
+    <div className="mb-3 text-lg font-bold text-white w-full flex items-center justify-between">
       {title}
       <span
-        className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none"
+        className="text-amber-400 transition-transform group-hover:translate-x-1 motion-reduce:transform-none"
         aria-hidden="true"
       >
-        -&gt;
+        →
       </span>
     </div>
   );
@@ -62,11 +44,12 @@ function CardDescription({
   size?: 'xs' | 'sm' | 'lg';
 }) {
   const sizeVariants = {
-    xs: 'text-xs opacity-50',
-    sm: 'text-sm opacity-50',
-    lg: 'text-lg opacity-85',
+    xs: 'text-xs text-slate-500',
+    sm: 'text-sm text-slate-400',
+    lg: 'text-lg text-amber-300 font-semibold',
   };
 
   return <p className={`w-full m-0 ${sizeVariants[size]}`}>{text}</p>;
 }
-export { CardClipWrapper, CardLinkWrapper, CardTitle, CardDescription };
+
+export { CardClipWrapper, CardTitle, CardDescription };

--- a/src/feature/contact/components/CardList.tsx
+++ b/src/feature/contact/components/CardList.tsx
@@ -3,7 +3,7 @@ import { CardDescription, CardTitle, CardClipWrapper } from './Card';
 
 export default function CardList() {
   return (
-    <div className="mb-16 grid text-center gap-5 items-center  justify-items-center md:px-10 md:grid-cols-2 lg:items-start lg:text-left w-full lg:mb-0  lg:max-w-5xl lg:grid-cols-4">
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 w-full">
       {PHONE_DATA.map(({ number, title, name }) => {
         return (
           <CardClipWrapper key={number} text={number}>

--- a/src/feature/suggest/component/SuggestForm.tsx
+++ b/src/feature/suggest/component/SuggestForm.tsx
@@ -14,26 +14,28 @@ export type State = {
   message?: string | null;
 };
 
+const fieldClass =
+  'w-full mt-1 p-3 border border-slate-200 rounded-xl text-slate-800 bg-white focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400 transition-colors';
+
+const labelClass = 'block text-sm font-semibold text-slate-700 mb-0.5';
+
 export default function SuggestForm() {
   const initialState: State = { message: '', errors: {} };
 
   const [state, dispatch] = useFormState(registerForm, initialState);
 
   return (
-    <form action={dispatch} className="space-y-4 w-full mx-auto">
+    <form action={dispatch} className="space-y-5 w-full">
       <div>
-        <label
-          htmlFor="grade"
-          className="block text-sm font-medium text-gray-700"
-        >
-          학년:
+        <label htmlFor="grade" className={labelClass}>
+          학년
         </label>
         <select
           id="grade"
           name="grade"
           defaultValue=""
           aria-describedby="grade-error"
-          className="w-full mt-1 p-2 border border-gray-300 rounded-md"
+          className={fieldClass}
         >
           <option value="" disabled>
             선택하세요
@@ -46,24 +48,21 @@ export default function SuggestForm() {
         </select>
         <div id="grade-error" aria-live="polite" aria-atomic="true">
           {state.errors?.grade && (
-            <p className="mt-2 text-sm text-red-500">{state.errors.grade}</p>
+            <p className="mt-1.5 text-sm text-red-500">{state.errors.grade}</p>
           )}
         </div>
       </div>
 
       <div>
-        <label
-          htmlFor="category"
-          className="block text-sm font-medium text-gray-700"
-        >
-          분류:
+        <label htmlFor="category" className={labelClass}>
+          분류
         </label>
         <select
           id="category"
           name="category"
           defaultValue=""
           aria-describedby="category-error"
-          className="w-full mt-1 p-2 border border-gray-300 rounded-md"
+          className={fieldClass}
         >
           <option value="" disabled>
             선택하세요
@@ -76,17 +75,14 @@ export default function SuggestForm() {
         </select>
         <div id="category-error" aria-live="polite" aria-atomic="true">
           {state.errors?.category && (
-            <p className="mt-2 text-sm text-red-500">{state.errors.category}</p>
+            <p className="mt-1.5 text-sm text-red-500">{state.errors.category}</p>
           )}
         </div>
       </div>
 
       <div>
-        <label
-          htmlFor="title"
-          className="block text-sm font-medium text-gray-700"
-        >
-          제목:
+        <label htmlFor="title" className={labelClass}>
+          제목
         </label>
         <input
           type="text"
@@ -94,40 +90,42 @@ export default function SuggestForm() {
           name="title"
           placeholder="제목을 입력해주세요"
           aria-describedby="title-error"
-          className="w-full mt-1 p-2 border border-gray-300 rounded-md"
+          className={fieldClass}
         />
         <div id="title-error" aria-live="polite" aria-atomic="true">
           {state.errors?.title && (
-            <p className="mt-2 text-sm text-red-500">{state.errors.title}</p>
+            <p className="mt-1.5 text-sm text-red-500">{state.errors.title}</p>
           )}
         </div>
       </div>
 
       <div>
-        <label
-          htmlFor="content"
-          className="block text-sm font-medium text-gray-700"
-        >
-          내용:
+        <label htmlFor="content" className={labelClass}>
+          내용
         </label>
         <textarea
           id="content"
           name="content"
+          placeholder="내용을 자유롭게 작성해주세요"
           aria-describedby="content-error"
-          className="w-full mt-1 p-2 border border-gray-300 rounded-md min-h-64"
+          className={`${fieldClass} min-h-48 resize-none`}
         />
         <div id="content-error" aria-live="polite" aria-atomic="true">
           {state.errors?.content && (
-            <p className="mt-2 text-sm text-red-500">{state.errors.content}</p>
+            <p className="mt-1.5 text-sm text-red-500">{state.errors.content}</p>
           )}
         </div>
       </div>
 
+      {state.message && (
+        <p className="text-sm text-amber-600 font-medium">{state.message}</p>
+      )}
+
       <button
         type="submit"
-        className="w-full p-2 bg-blue-500 text-white font-semibold rounded-md hover:bg-blue-600"
+        className="w-full py-3 px-6 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold rounded-xl transition-colors text-base shadow-md shadow-amber-500/20"
       >
-        제출
+        제출하기
       </button>
     </form>
   );

--- a/src/shared/components/FloatingBtn.tsx
+++ b/src/shared/components/FloatingBtn.tsx
@@ -1,83 +1,128 @@
 'use client';
 
-import Image from 'next/image';
-import React from 'react';
-import { useRouter } from 'next/navigation'; // useRouter import
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { PHONE_DATA, NAVER_MAP_URL } from '../const';
 
-const FloatingBtn = () => {
-  const router = useRouter(); // useRouter 호출
+const PhoneIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+  </svg>
+);
 
-  // 이동 함수는 컴포넌트 내부에서 선언
-  const icons = [
+const MapPinIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+  </svg>
+);
+
+const ChatIcon = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+  </svg>
+);
+
+const PlusIcon = () => (
+  <svg className="w-6 h-6 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+  </svg>
+);
+
+const CloseIcon = () => (
+  <svg className="w-6 h-6 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+export default function FloatingBtn() {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  const actions = [
     {
-      src: '/consulting.svg',
-      alt: '상담 아이콘',
-      text: '상담 번호',
-      func: () => {
+      icon: <PhoneIcon />,
+      label: '상담 번호',
+      onClick: () => {
         navigator.clipboard.writeText(PHONE_DATA[0].number);
         alert(`${PHONE_DATA[0].number}가 클립보드에 복사되었습니다`);
+        setOpen(false);
       },
     },
     {
-      src: '/marker.svg',
-      alt: '길찾기',
-      text: '길 찾기',
-      func: () => {
+      icon: <MapPinIcon />,
+      label: '길 찾기',
+      onClick: () => {
         window.open(NAVER_MAP_URL, '_blank', 'noopener,noreferrer');
+        setOpen(false);
       },
     },
     {
-      src: '/suggest.svg',
-      alt: '건의함 아이콘',
-      text: '익명 건의함',
-      func: () => router.push('/suggest'), // 페이지 이동 함수
+      icon: <ChatIcon />,
+      label: '익명 건의함',
+      onClick: () => {
+        router.push('/suggest');
+        setOpen(false);
+      },
     },
   ];
 
   return (
-    <section className="fixed bottom-5 right-5 z-50 md:bottom-[6%] md:right-[9%] space-y-2 md:space-y-4">
-      {icons.map((icon, index) => (
-        <FloatingIcon
-          key={index}
-          src={icon.src}
-          alt={icon.alt}
-          text={icon.text}
-          func={icon.func}
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
+      {/* 액션 버튼들 */}
+      <div className="flex flex-col items-end gap-2">
+        {actions.map((action, index) => (
+          <div
+            key={action.label}
+            className={`flex items-center gap-2 transition-all duration-300 ${
+              open
+                ? 'opacity-100 translate-y-0'
+                : 'opacity-0 translate-y-4 pointer-events-none'
+            }`}
+            style={{ transitionDelay: open ? `${index * 60}ms` : '0ms' }}
+          >
+            {/* 라벨 */}
+            <span className="bg-slate-900 text-white text-xs font-medium px-3 py-1.5 rounded-lg shadow-md whitespace-nowrap border border-slate-700">
+              {action.label}
+            </span>
+            {/* 아이콘 버튼 */}
+            <button
+              onClick={action.onClick}
+              className="w-11 h-11 rounded-full bg-slate-800 border border-slate-700 text-amber-400 shadow-lg hover:bg-slate-700 hover:border-amber-500/50 transition-colors flex items-center justify-center"
+              aria-label={action.label}
+            >
+              {action.icon}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* 메인 FAB */}
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label={open ? '메뉴 닫기' : '빠른 메뉴 열기'}
+        aria-expanded={open}
+        className={`w-14 h-14 rounded-full shadow-xl flex items-center justify-center transition-colors duration-200 ${
+          open
+            ? 'bg-slate-800 border border-slate-600 text-white'
+            : 'bg-amber-500 hover:bg-amber-400 text-slate-900'
+        }`}
+      >
+        {open ? <CloseIcon /> : <PlusIcon />}
+      </button>
+
+      {/* 배경 오버레이 (클릭으로 닫기) */}
+      {open && (
+        <div
+          className="fixed inset-0 -z-10"
+          onClick={() => setOpen(false)}
+          aria-hidden="true"
         />
-      ))}
-    </section>
+      )}
+    </div>
   );
-};
-
-export default FloatingBtn;
-
-interface FloatingIconProps {
-  src: string;
-  alt: string;
-  text: string;
-  func: () => void;
 }
-
-const FloatingIcon: React.FC<FloatingIconProps> = ({
-  src,
-  alt,
-  text,
-  func,
-}) => {
-  return (
-    <button
-      onClick={func}
-      className="flex flex-col items-center justify-center w-[80px] h-[80px] md:w-[110px] md:h-[110px] rounded-full bg-white shadow-lg"
-    >
-      <Image
-        src={src}
-        alt={alt}
-        width={40}
-        height={40}
-        className="cursor-pointer md:w-[70px] md:h-[70px]"
-      />
-      <p className="text-center text-xs md:text-sm">{text}</p>
-    </button>
-  );
-};


### PR DESCRIPTION
- Contact/Suggest 페이지에 ContentWrapper 구조 적용
- Card, Address, SuggestForm gray 계열 → slate/amber 색상 시스템 통일
- FloatingBtn을 스피드 다이얼 방식으로 교체 (amber FAB + 옵션 펼침)
- SVG 이미지 파일 → 인라인 SVG로 교체, 임의값 제거